### PR TITLE
ci: run build-docs against latest Node LTS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
-        # node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description, Motivation and Context

- Why is this change required?
- What does it do?

## Checklist:

- [ ] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
