### PR TITLE
chore: bump typescript to ^4.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "qs": "^6.11.1",
     "randomstring": "^1.2.3",
     "ts-morph": "^8.2.0",
-    "typescript": "4.3.4",
+    "typescript": "^4.9.5",
     "validator": "^13.9.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7175,10 +7175,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
-  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 typescript@~4.0.2:
   version "4.0.8"


### PR DESCRIPTION
This was kept to a lower version to due to issues with webpack v4 and
its dependencies.

## Description, Motivation and Context

- Why is this change required?
- What does it do?

## Checklist:

- [ ] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
